### PR TITLE
D83T-18: 카카오 id 조회 서비스 구현

### DIFF
--- a/src/main/java/d83t/bpmbackend/domain/aggregate/user/controller/UserController.java
+++ b/src/main/java/d83t/bpmbackend/domain/aggregate/user/controller/UserController.java
@@ -4,8 +4,11 @@ import d83t.bpmbackend.domain.aggregate.profile.dto.ProfileDto;
 import d83t.bpmbackend.domain.aggregate.profile.dto.ProfileRequest;
 import d83t.bpmbackend.domain.aggregate.profile.dto.ProfileResponse;
 import d83t.bpmbackend.domain.aggregate.user.service.UserService;
+import d83t.bpmbackend.exception.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -24,5 +27,13 @@ public class UserController {
             @ModelAttribute ProfileRequest profileRequest,
             @RequestParam MultipartFile file) {
         return userService.signUp(kakaoId, profileRequest, file);
+    }
+
+    @Operation(summary = "카카오 uuid 체크 API", description = "카카오 uid을 받아 이미 있는 유저인지 판단하는 API입니다.")
+    @ApiResponse(responseCode = "200", description = "카카오 uuid가 조회되었습니다.", content = @Content(schema = @Schema(implementation = ProfileResponse.class)))
+    @ApiResponse(responseCode = "404", description = "카카오 uuid를 찾지 못하였습니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    @GetMapping(path = "/{kakaoId}/verification")
+    public ProfileResponse verification(@PathVariable Long kakaoId) {
+        return userService.verification(kakaoId);
     }
 }

--- a/src/main/java/d83t/bpmbackend/domain/aggregate/user/repository/UserRepository.java
+++ b/src/main/java/d83t/bpmbackend/domain/aggregate/user/repository/UserRepository.java
@@ -2,6 +2,13 @@ package d83t.bpmbackend.domain.aggregate.user.repository;
 
 import d83t.bpmbackend.domain.aggregate.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+
+    @Query("SELECT user FROM User user WHERE user.kakaoId = :kakaoId")
+    Optional<User> findByKakaoId(@Param(value = "kakaoId") Long kakaoId);
 }

--- a/src/main/java/d83t/bpmbackend/domain/aggregate/user/service/UserService.java
+++ b/src/main/java/d83t/bpmbackend/domain/aggregate/user/service/UserService.java
@@ -6,4 +6,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 public interface UserService {
     ProfileResponse signUp(Long kakaoId, ProfileRequest profileRequest, MultipartFile file);
+
+    ProfileResponse verification(Long kakaoId);
 }

--- a/src/main/java/d83t/bpmbackend/domain/aggregate/user/service/UserServiceImpl.java
+++ b/src/main/java/d83t/bpmbackend/domain/aggregate/user/service/UserServiceImpl.java
@@ -7,20 +7,24 @@ import d83t.bpmbackend.domain.aggregate.profile.entity.Profile;
 import d83t.bpmbackend.domain.aggregate.profile.service.ProfileImageService;
 import d83t.bpmbackend.domain.aggregate.user.entity.User;
 import d83t.bpmbackend.domain.aggregate.user.repository.UserRepository;
+import d83t.bpmbackend.exception.CustomException;
+import d83t.bpmbackend.exception.Error;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.Optional;
+
 @RequiredArgsConstructor
 @Service
-public class UserServiceImpl implements UserService{
+public class UserServiceImpl implements UserService {
 
     private final ProfileImageService profileImageService;
     private final UserRepository userRepository;
 
     @Override
     public ProfileResponse signUp(Long kakaoId, ProfileRequest profileRequest, MultipartFile file) {
-        ProfileDto profileDto = profileImageService.setUploadFile(profileRequest,file);
+        ProfileDto profileDto = profileImageService.setUploadFile(profileRequest, file);
 
         Profile profile = profileImageService.convertProfileDto(profileDto);
         User user = User.builder()
@@ -31,6 +35,18 @@ public class UserServiceImpl implements UserService{
         return ProfileResponse.builder()
                 .nickname(profileDto.getNickname())
                 .bio(profileRequest.getBio())
+                .build();
+    }
+
+    @Override
+    public ProfileResponse verification(Long kakaoId) {
+        Optional<User> user = Optional.ofNullable(userRepository.findByKakaoId(kakaoId).orElseThrow(
+                () -> new CustomException(Error.NOT_FOUND_USER_ID))
+        );
+        Profile userProfile = user.get().getProfile();
+        return ProfileResponse.builder()
+                .nickname(userProfile.getNickName())
+                .bio(userProfile.getBio())
                 .build();
     }
 }

--- a/src/main/java/d83t/bpmbackend/exception/Error.java
+++ b/src/main/java/d83t/bpmbackend/exception/Error.java
@@ -5,12 +5,13 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public enum Error {
+    NOT_FOUND_USER_ID("kakao user not found", HttpStatus.NOT_FOUND),
     DUPLICATE_USER_NICK_NAME("duplicate user nickname", HttpStatus.CONFLICT);
 
     private final String message;
     private final HttpStatus status;
 
-    Error(String message, HttpStatus status){
+    Error(String message, HttpStatus status) {
         this.message = message;
         this.status = status;
     }

--- a/src/test/java/d83t/bpmbackend/domain/aggregate/user/controller/UserControllerTest.java
+++ b/src/test/java/d83t/bpmbackend/domain/aggregate/user/controller/UserControllerTest.java
@@ -1,0 +1,58 @@
+package d83t.bpmbackend.domain.aggregate.user.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import d83t.bpmbackend.domain.aggregate.profile.dto.ProfileResponse;
+import d83t.bpmbackend.domain.aggregate.user.service.UserServiceImpl;
+import d83t.bpmbackend.exception.CustomException;
+import d83t.bpmbackend.exception.Error;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import java.util.Random;
+
+@WebMvcTest(controllers = UserController.class)
+class UserControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockBean
+    UserServiceImpl userService;
+
+    @Test
+    void 카카오_ID_검증_성공() throws Exception {
+        Random random = new Random();
+        Long kakaoId = random.nextLong();
+        ProfileResponse profileResponse = ProfileResponse.builder()
+                .nickname("nickname")
+                .bio("bio")
+                .build();
+
+        Mockito.when(userService.verification(Mockito.eq(kakaoId))).thenReturn(profileResponse);
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/users/"+ kakaoId +"/verification"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.profile.nickname", Matchers.equalTo(profileResponse.getNickname())))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.profile.bio", Matchers.equalTo(profileResponse.getBio())));
+    }
+
+    @Test
+    void 카카오_ID_검증_실패() throws Exception {
+        Random random = new Random();
+        Long kakaoId = random.nextLong();
+
+        Mockito.when(userService.verification(Mockito.any(Long.class))).thenThrow(new CustomException(Error.NOT_FOUND_USER_ID));
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/users/"+ kakaoId +"/verification"))
+                .andExpect(MockMvcResultMatchers.status().isNotFound())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.errors.message", Matchers.equalTo(Error.NOT_FOUND_USER_ID.getMessage())));
+    }
+}


### PR DESCRIPTION
# 개요
- 카카오ID 서비스 조회 서비스 구현

# 상세내용
- 카카오 ID를 데이터베이스에서 조회하여, 있으면 200 ok 없으면 404error를 반환 합니다.

# 테스트
- 컨트롤러 테스트코드 작성  
![image](https://user-images.githubusercontent.com/30401054/219958088-b1d51b81-f3da-40f3-969e-8750e62ce4e8.png)

