### PR TITLE
D83T-36 내눈바디 등록하기 API 구현

### DIFF
--- a/src/main/java/d83t/bpmbackend/domain/aggregate/community/controller/BodyShapeController.java
+++ b/src/main/java/d83t/bpmbackend/domain/aggregate/community/controller/BodyShapeController.java
@@ -1,0 +1,31 @@
+package d83t.bpmbackend.domain.aggregate.community.controller;
+
+import d83t.bpmbackend.domain.aggregate.community.dto.BodyShapeRequest;
+import d83t.bpmbackend.domain.aggregate.community.dto.BodyShapeResponse;
+import d83t.bpmbackend.domain.aggregate.community.service.BodyShapeService;
+import d83t.bpmbackend.domain.aggregate.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/community/body-shape")
+@Slf4j
+public class BodyShapeController {
+
+    private final BodyShapeService bodyShapeService;
+
+    @PostMapping
+    public BodyShapeResponse createBoastArticle(
+            @AuthenticationPrincipal User user,
+            @RequestPart List<MultipartFile> files,
+            @ModelAttribute BodyShapeRequest bodyShapeRequest) {
+        log.info(files.toString());
+        return bodyShapeService.createBoastArticle(user, files, bodyShapeRequest);
+    }
+}

--- a/src/main/java/d83t/bpmbackend/domain/aggregate/community/dto/BodyShapeRequest.java
+++ b/src/main/java/d83t/bpmbackend/domain/aggregate/community/dto/BodyShapeRequest.java
@@ -1,0 +1,19 @@
+package d83t.bpmbackend.domain.aggregate.community.dto;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import lombok.*;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Setter
+@JsonTypeName("boast")
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
+@ToString
+public class BodyShapeRequest {
+
+    private String content;
+
+}

--- a/src/main/java/d83t/bpmbackend/domain/aggregate/community/dto/BodyShapeResponse.java
+++ b/src/main/java/d83t/bpmbackend/domain/aggregate/community/dto/BodyShapeResponse.java
@@ -1,5 +1,7 @@
 package d83t.bpmbackend.domain.aggregate.community.dto;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.web.multipart.MultipartFile;
@@ -9,13 +11,15 @@ import java.util.List;
 
 @Builder
 @Getter
+@JsonTypeName("boast")
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
 public class BodyShapeResponse {
     private String content;
 
     private ZonedDateTime createdAt;
     private ZonedDateTime updatedAt;
 
-    private List<MultipartFile> files;
+    private List<String> filesPath;
 
     private Author author;
 
@@ -23,6 +27,6 @@ public class BodyShapeResponse {
     @Getter
     public static class Author{
         private String nickname;
-        private MultipartFile profileImage;
+        private String profilePath;
     }
 }

--- a/src/main/java/d83t/bpmbackend/domain/aggregate/community/dto/BodyShapeResponse.java
+++ b/src/main/java/d83t/bpmbackend/domain/aggregate/community/dto/BodyShapeResponse.java
@@ -1,0 +1,28 @@
+package d83t.bpmbackend.domain.aggregate.community.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+
+@Builder
+@Getter
+public class BodyShapeResponse {
+    private String content;
+
+    private ZonedDateTime createdAt;
+    private ZonedDateTime updatedAt;
+
+    private List<MultipartFile> files;
+
+    private Author author;
+
+    @Builder
+    @Getter
+    public static class Author{
+        private String nickname;
+        private MultipartFile profileImage;
+    }
+}

--- a/src/main/java/d83t/bpmbackend/domain/aggregate/community/entity/BodyShape.java
+++ b/src/main/java/d83t/bpmbackend/domain/aggregate/community/entity/BodyShape.java
@@ -8,6 +8,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Builder
 @Entity
 @Getter
@@ -23,8 +26,18 @@ public class BodyShape extends DateEntity {
     @Column
     private String content;
 
+    @OneToMany(mappedBy = "bodyShape", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<BodyShapeImage> images;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(nullable = false)
     private Profile author;
+
+    public void addBodyShapeImage(BodyShapeImage bodyShapeImage){
+        if(this.images == null){
+            this.images = new ArrayList<>();
+        }
+        this.images.add(bodyShapeImage);
+    }
 
 }

--- a/src/main/java/d83t/bpmbackend/domain/aggregate/community/entity/BodyShape.java
+++ b/src/main/java/d83t/bpmbackend/domain/aggregate/community/entity/BodyShape.java
@@ -1,0 +1,30 @@
+package d83t.bpmbackend.domain.aggregate.community.entity;
+
+import d83t.bpmbackend.base.entity.DateEntity;
+import d83t.bpmbackend.domain.aggregate.profile.entity.Profile;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "Boast")
+public class BodyShape extends DateEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false)
+    private Profile author;
+
+}

--- a/src/main/java/d83t/bpmbackend/domain/aggregate/community/entity/BodyShapeImage.java
+++ b/src/main/java/d83t/bpmbackend/domain/aggregate/community/entity/BodyShapeImage.java
@@ -1,0 +1,29 @@
+package d83t.bpmbackend.domain.aggregate.community.entity;
+
+import d83t.bpmbackend.base.entity.DateEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "BoastImage")
+public class BodyShapeImage extends DateEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private BodyShape bodyShape;
+
+    @Column(name = "filename", nullable = false)
+    private String originFileName;
+
+    @Column(name = "path", nullable = false)
+    private String storagePathName;
+}

--- a/src/main/java/d83t/bpmbackend/domain/aggregate/community/repository/BodyShapeRepository.java
+++ b/src/main/java/d83t/bpmbackend/domain/aggregate/community/repository/BodyShapeRepository.java
@@ -1,0 +1,7 @@
+package d83t.bpmbackend.domain.aggregate.community.repository;
+
+import d83t.bpmbackend.domain.aggregate.community.entity.BodyShape;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BodyShapeRepository extends JpaRepository<BodyShape, Long> {
+}

--- a/src/main/java/d83t/bpmbackend/domain/aggregate/community/service/BodyShapeService.java
+++ b/src/main/java/d83t/bpmbackend/domain/aggregate/community/service/BodyShapeService.java
@@ -1,0 +1,14 @@
+package d83t.bpmbackend.domain.aggregate.community.service;
+
+import d83t.bpmbackend.domain.aggregate.community.dto.BodyShapeRequest;
+import d83t.bpmbackend.domain.aggregate.community.dto.BodyShapeResponse;
+import d83t.bpmbackend.domain.aggregate.user.entity.User;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+public interface BodyShapeService {
+
+
+    BodyShapeResponse createBoastArticle(User user, List<MultipartFile> files, BodyShapeRequest boastArticleRequest);
+}

--- a/src/main/java/d83t/bpmbackend/domain/aggregate/community/service/BodyShapeServiceImpl.java
+++ b/src/main/java/d83t/bpmbackend/domain/aggregate/community/service/BodyShapeServiceImpl.java
@@ -3,16 +3,16 @@ package d83t.bpmbackend.domain.aggregate.community.service;
 import d83t.bpmbackend.domain.aggregate.community.dto.BodyShapeRequest;
 import d83t.bpmbackend.domain.aggregate.community.dto.BodyShapeResponse;
 import d83t.bpmbackend.domain.aggregate.community.entity.BodyShape;
+import d83t.bpmbackend.domain.aggregate.community.entity.BodyShapeImage;
 import d83t.bpmbackend.domain.aggregate.community.repository.BodyShapeRepository;
-import d83t.bpmbackend.domain.aggregate.profile.dto.ProfileDto;
 import d83t.bpmbackend.domain.aggregate.profile.entity.Profile;
-import d83t.bpmbackend.domain.aggregate.profile.repository.ProfileRepository;
 import d83t.bpmbackend.domain.aggregate.user.entity.User;
 import d83t.bpmbackend.domain.aggregate.user.repository.UserRepository;
 import d83t.bpmbackend.exception.CustomException;
 import d83t.bpmbackend.exception.Error;
 import d83t.bpmbackend.s3.S3UploaderService;
 import jakarta.annotation.PostConstruct;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -21,6 +21,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -52,11 +53,18 @@ public class BodyShapeServiceImpl implements BodyShapeService {
     }
 
     @Override
+    @Transactional
     public BodyShapeResponse createBoastArticle(User user, List<MultipartFile> files, BodyShapeRequest bodyShapeRequest) {
+        //file은 최대 5개만 들어올 수 있다.
+        if(files.size() > 5){
+            throw new CustomException(Error.FILE_SIZE_MAX);
+        }
+
         Optional<User> findUser = userRepository.findByKakaoId(user.getKakaoId());
         if (findUser.isEmpty()) {
             throw new CustomException(Error.NOT_FOUND_USER_ID);
         }
+        List<String> filePaths = new ArrayList<>();
 
         Profile profile = findUser.get().getProfile();
         BodyShape bodyshape = BodyShape.builder()
@@ -67,6 +75,11 @@ public class BodyShapeServiceImpl implements BodyShapeService {
         for (MultipartFile file : files) {
             String newName = createNewFileName(file.getOriginalFilename());
             String filePath = fileDir + newName;
+            bodyshape.addBodyShapeImage(BodyShapeImage.builder()
+                    .originFileName(newName)
+                    .storagePathName(filePath)
+                    .build());
+            filePaths.add(filePath);
             if (env.equals("prod")) {
                 uploaderService.putS3(file, bodyShapePath, newName);
             } else if (env.equals("local")) {
@@ -81,16 +94,15 @@ public class BodyShapeServiceImpl implements BodyShapeService {
         }
 
         bodyShapeRepository.save(bodyshape);
-        //profileDto.setImageName(newName);
-        //profileDto.setImagePath(filePath);
 
         return BodyShapeResponse.builder()
                 .createdAt(bodyshape.getCreatedDate())
                 .author(BodyShapeResponse.Author.builder()
                         .nickname(profile.getNickName())
-                        .profileImage(null)
+                        .profilePath(profile.getStoragePathName())
                         .build())
                 .updatedAt(bodyshape.getModifiedDate())
+                .filesPath(filePaths)
                 .content(bodyshape.getContent())
                 .build();
     }
@@ -104,7 +116,7 @@ public class BodyShapeServiceImpl implements BodyShapeService {
     }
 
     private String getUploadPath() {
-        String path = new File("").getAbsolutePath() + "\\" + "bodyShapes\\";
+        String path = new File("").getAbsolutePath() + "/" + "bodyShapes/";
         File file = new File(path);
         if (!file.exists()) {
             file.mkdir();

--- a/src/main/java/d83t/bpmbackend/domain/aggregate/community/service/BodyShapeServiceImpl.java
+++ b/src/main/java/d83t/bpmbackend/domain/aggregate/community/service/BodyShapeServiceImpl.java
@@ -1,0 +1,118 @@
+package d83t.bpmbackend.domain.aggregate.community.service;
+
+import d83t.bpmbackend.domain.aggregate.community.dto.BodyShapeRequest;
+import d83t.bpmbackend.domain.aggregate.community.dto.BodyShapeResponse;
+import d83t.bpmbackend.domain.aggregate.community.entity.BodyShape;
+import d83t.bpmbackend.domain.aggregate.community.repository.BodyShapeRepository;
+import d83t.bpmbackend.domain.aggregate.profile.dto.ProfileDto;
+import d83t.bpmbackend.domain.aggregate.profile.entity.Profile;
+import d83t.bpmbackend.domain.aggregate.profile.repository.ProfileRepository;
+import d83t.bpmbackend.domain.aggregate.user.entity.User;
+import d83t.bpmbackend.domain.aggregate.user.repository.UserRepository;
+import d83t.bpmbackend.exception.CustomException;
+import d83t.bpmbackend.exception.Error;
+import d83t.bpmbackend.s3.S3UploaderService;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class BodyShapeServiceImpl implements BodyShapeService {
+
+    private final UserRepository userRepository;
+    private final S3UploaderService uploaderService;
+    private final BodyShapeRepository bodyShapeRepository;
+
+    @Value("${bpm.s3.bucket.bodyshape.path}")
+    private String bodyShapePath;
+
+    @Value("${spring.environment}")
+    private String env;
+
+    private String fileDir;
+
+    @PostConstruct
+    private void init() {
+        if (env.equals("local")) {
+            this.fileDir = getUploadPath();
+        } else if (env.equals("prod")) {
+            this.fileDir = this.bodyShapePath;
+        }
+    }
+
+    @Override
+    public BodyShapeResponse createBoastArticle(User user, List<MultipartFile> files, BodyShapeRequest bodyShapeRequest) {
+        Optional<User> findUser = userRepository.findByKakaoId(user.getKakaoId());
+        if (findUser.isEmpty()) {
+            throw new CustomException(Error.NOT_FOUND_USER_ID);
+        }
+
+        Profile profile = findUser.get().getProfile();
+        BodyShape bodyshape = BodyShape.builder()
+                .author(profile)
+                .content(bodyShapeRequest.getContent())
+                .build();
+
+        for (MultipartFile file : files) {
+            String newName = createNewFileName(file.getOriginalFilename());
+            String filePath = fileDir + newName;
+            if (env.equals("prod")) {
+                uploaderService.putS3(file, bodyShapePath, newName);
+            } else if (env.equals("local")) {
+                try {
+                    File localFile = new File(filePath);
+                    file.transferTo(localFile);
+                    removeNewFile(localFile);
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+
+        bodyShapeRepository.save(bodyshape);
+        //profileDto.setImageName(newName);
+        //profileDto.setImagePath(filePath);
+
+        return BodyShapeResponse.builder()
+                .createdAt(bodyshape.getCreatedDate())
+                .author(BodyShapeResponse.Author.builder()
+                        .nickname(profile.getNickName())
+                        .profileImage(null)
+                        .build())
+                .updatedAt(bodyshape.getModifiedDate())
+                .content(bodyshape.getContent())
+                .build();
+    }
+
+    private void removeNewFile(File targetFile) {
+        if (targetFile.delete()) {
+            log.info("file delete success");
+            return;
+        }
+        log.info("file delete fail");
+    }
+
+    private String getUploadPath() {
+        String path = new File("").getAbsolutePath() + "\\" + "bodyShapes\\";
+        File file = new File(path);
+        if (!file.exists()) {
+            file.mkdir();
+        }
+        return path;
+    }
+
+    private String createNewFileName(String originalName) {
+        return UUID.randomUUID() + "." + originalName.substring(originalName.lastIndexOf("."));
+    }
+}

--- a/src/main/java/d83t/bpmbackend/domain/aggregate/profile/dto/ProfileResponse.java
+++ b/src/main/java/d83t/bpmbackend/domain/aggregate/profile/dto/ProfileResponse.java
@@ -17,5 +17,6 @@ public class ProfileResponse {
     private String nickname;
     private String bio;
     private String token;
+    private String image;
 
 }

--- a/src/main/java/d83t/bpmbackend/domain/aggregate/profile/entity/Profile.java
+++ b/src/main/java/d83t/bpmbackend/domain/aggregate/profile/entity/Profile.java
@@ -1,11 +1,14 @@
 package d83t.bpmbackend.domain.aggregate.profile.entity;
 
+import d83t.bpmbackend.domain.aggregate.community.entity.BodyShape;
 import d83t.bpmbackend.domain.aggregate.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 
 @Builder
@@ -34,5 +37,8 @@ public class Profile {
 
     @OneToOne(mappedBy = "profile")
     private User user;
+
+    @OneToMany(mappedBy = "author", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<BodyShape> myBodyShapes;
 
 }

--- a/src/main/java/d83t/bpmbackend/domain/aggregate/profile/service/ProfileImageServiceImpl.java
+++ b/src/main/java/d83t/bpmbackend/domain/aggregate/profile/service/ProfileImageServiceImpl.java
@@ -88,7 +88,7 @@ public class ProfileImageServiceImpl implements ProfileImageService {
     }
 
     private String getUploadPath() {
-        String path = new File("").getAbsolutePath() + "\\" + "images\\";
+        String path = new File("").getAbsolutePath() + "/" + "images/";
         File file = new File(path);
         if (!file.exists()) {
             file.mkdir();

--- a/src/main/java/d83t/bpmbackend/domain/aggregate/profile/service/UserServiceDetail.java
+++ b/src/main/java/d83t/bpmbackend/domain/aggregate/profile/service/UserServiceDetail.java
@@ -2,9 +2,12 @@ package d83t.bpmbackend.domain.aggregate.profile.service;
 
 import d83t.bpmbackend.domain.aggregate.profile.entity.Profile;
 import d83t.bpmbackend.domain.aggregate.profile.repository.ProfileRepository;
+import d83t.bpmbackend.domain.aggregate.user.entity.User;
+import d83t.bpmbackend.domain.aggregate.user.repository.UserRepository;
 import d83t.bpmbackend.exception.CustomException;
 import d83t.bpmbackend.exception.Error;
 import lombok.AllArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -17,15 +20,15 @@ import java.util.Optional;
 public class UserServiceDetail implements UserDetailsService {
 
     private final ProfileRepository profileRepository;
+    private final UserRepository userRepository;
 
     @Override
     public UserDetails loadUserByUsername(String nickName) throws UsernameNotFoundException {
         Optional<Profile> profile = profileRepository.findByNickName(nickName);
-
         if(profile.isEmpty()){
             throw new CustomException(Error.NOT_FOUND_USER_ID);
         }
-        return new org.springframework.security.core.userdetails.User(profile.get().getNickName(), "",null);
-
+        Optional<User> user = userRepository.findById(profile.get().getUser().getId());
+        return user.get();
     }
 }

--- a/src/main/java/d83t/bpmbackend/domain/aggregate/user/entity/User.java
+++ b/src/main/java/d83t/bpmbackend/domain/aggregate/user/entity/User.java
@@ -28,7 +28,7 @@ public class User extends DateEntity implements UserDetails {
     @Column(nullable = false, unique = true)
     private Long kakaoId;
 
-    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(nullable = false)
     private Profile profile;
 

--- a/src/main/java/d83t/bpmbackend/domain/aggregate/user/entity/User.java
+++ b/src/main/java/d83t/bpmbackend/domain/aggregate/user/entity/User.java
@@ -7,7 +7,10 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
 
+import java.util.Collection;
 
 
 @Builder
@@ -16,7 +19,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "users")
-public class User extends DateEntity {
+public class User extends DateEntity implements UserDetails {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -25,8 +28,42 @@ public class User extends DateEntity {
     @Column(nullable = false, unique = true)
     private Long kakaoId;
 
-    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(nullable = false)
     private Profile profile;
 
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return null;
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return null;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return false;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return false;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return false;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return false;
+    }
 }

--- a/src/main/java/d83t/bpmbackend/domain/aggregate/user/service/UserServiceImpl.java
+++ b/src/main/java/d83t/bpmbackend/domain/aggregate/user/service/UserServiceImpl.java
@@ -47,7 +47,8 @@ public class UserServiceImpl implements UserService {
         userRepository.save(user);
         return ProfileResponse.builder()
                 .nickname(profileDto.getNickname())
-                .bio(profileRequest.getBio())
+                .bio(profileDto.getBio())
+                .image(profileDto.getImagePath())
                 .token(jwtService.createToken(profileRequest.getNickname()))
                 .build();
     }

--- a/src/main/java/d83t/bpmbackend/domain/aggregate/user/service/UserServiceImpl.java
+++ b/src/main/java/d83t/bpmbackend/domain/aggregate/user/service/UserServiceImpl.java
@@ -4,6 +4,7 @@ import d83t.bpmbackend.domain.aggregate.profile.dto.ProfileDto;
 import d83t.bpmbackend.domain.aggregate.profile.dto.ProfileRequest;
 import d83t.bpmbackend.domain.aggregate.profile.dto.ProfileResponse;
 import d83t.bpmbackend.domain.aggregate.profile.entity.Profile;
+import d83t.bpmbackend.domain.aggregate.profile.repository.ProfileRepository;
 import d83t.bpmbackend.domain.aggregate.profile.service.ProfileImageService;
 import d83t.bpmbackend.domain.aggregate.user.entity.User;
 import d83t.bpmbackend.domain.aggregate.user.repository.UserRepository;
@@ -22,6 +23,7 @@ public class UserServiceImpl implements UserService {
 
     private final ProfileImageService profileImageService;
     private final UserRepository userRepository;
+    private final ProfileRepository profileRepository;
 
     private final JwtService jwtService;
 
@@ -30,6 +32,10 @@ public class UserServiceImpl implements UserService {
         Optional<User> findUser = userRepository.findByKakaoId(kakaoId);
         if(findUser.isPresent()){
             throw new CustomException(Error.USER_ALREADY_EXITS);
+        }
+        //닉네임 중복여부
+        if(profileRepository.findByNickName(profileRequest.getNickname()).isPresent()){
+            throw new CustomException(Error.USER_NICKNAME_ALREADY_EXITS);
         }
         ProfileDto profileDto = profileImageService.setUploadFile(profileRequest, file);
 

--- a/src/main/java/d83t/bpmbackend/exception/Error.java
+++ b/src/main/java/d83t/bpmbackend/exception/Error.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 public enum Error {
     NOT_FOUND_USER_ID("kakao user not found", HttpStatus.NOT_FOUND),
     USER_ALREADY_EXITS("user already exits", HttpStatus.CONFLICT),
+    USER_NICKNAME_ALREADY_EXITS("user nickname already exits", HttpStatus.CONFLICT),
     S3_UPLOAD_FAIL("upload fail", HttpStatus.INTERNAL_SERVER_ERROR),
     DUPLICATE_USER_NICK_NAME("duplicate user nickname", HttpStatus.CONFLICT);
 

--- a/src/main/java/d83t/bpmbackend/exception/Error.java
+++ b/src/main/java/d83t/bpmbackend/exception/Error.java
@@ -9,7 +9,9 @@ public enum Error {
     USER_ALREADY_EXITS("user already exits", HttpStatus.CONFLICT),
     USER_NICKNAME_ALREADY_EXITS("user nickname already exits", HttpStatus.CONFLICT),
     S3_UPLOAD_FAIL("upload fail", HttpStatus.INTERNAL_SERVER_ERROR),
-    DUPLICATE_USER_NICK_NAME("duplicate user nickname", HttpStatus.CONFLICT);
+    S3_GET_FILE_FAIL("fail to get file", HttpStatus.INTERNAL_SERVER_ERROR),
+    DUPLICATE_USER_NICK_NAME("duplicate user nickname", HttpStatus.CONFLICT),
+    FILE_SIZE_MAX("a Maximum of 5 files can Come in", HttpStatus.BAD_REQUEST);
 
     private final String message;
     private final HttpStatus status;

--- a/src/main/java/d83t/bpmbackend/s3/S3UploaderService.java
+++ b/src/main/java/d83t/bpmbackend/s3/S3UploaderService.java
@@ -1,0 +1,8 @@
+package d83t.bpmbackend.s3;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface S3UploaderService {
+
+    void putS3(MultipartFile uploadFile, String path, String fileName);
+}

--- a/src/main/java/d83t/bpmbackend/s3/S3UploaderServiceImpl.java
+++ b/src/main/java/d83t/bpmbackend/s3/S3UploaderServiceImpl.java
@@ -1,0 +1,37 @@
+package d83t.bpmbackend.s3;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import d83t.bpmbackend.exception.CustomException;
+import d83t.bpmbackend.exception.Error;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@Service
+@RequiredArgsConstructor
+public class S3UploaderServiceImpl implements S3UploaderService{
+
+    private final AmazonS3 s3Client;
+
+    @Value("${aws.s3.bucketName}")
+    private String bucket;
+
+    public void putS3(MultipartFile uploadFile, String path, String fileName) {
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentType(uploadFile.getContentType());
+        metadata.setContentLength(uploadFile.getSize());
+        fileName = path + "/" + fileName;
+        try {
+            PutObjectRequest request = new PutObjectRequest(bucket, fileName, uploadFile.getInputStream(), metadata);
+            s3Client.putObject(request);
+        } catch (IOException e) {
+            throw new CustomException(Error.S3_UPLOAD_FAIL);
+        }
+    }
+
+}

--- a/src/main/java/d83t/bpmbackend/s3/S3UploaderServiceImpl.java
+++ b/src/main/java/d83t/bpmbackend/s3/S3UploaderServiceImpl.java
@@ -14,7 +14,7 @@ import java.io.IOException;
 
 @Service
 @RequiredArgsConstructor
-public class S3UploaderServiceImpl implements S3UploaderService{
+public class S3UploaderServiceImpl implements S3UploaderService {
 
     private final AmazonS3 s3Client;
 
@@ -25,7 +25,7 @@ public class S3UploaderServiceImpl implements S3UploaderService{
         ObjectMetadata metadata = new ObjectMetadata();
         metadata.setContentType(uploadFile.getContentType());
         metadata.setContentLength(uploadFile.getSize());
-        fileName = path + "/" + fileName;
+        fileName = path + fileName;
         try {
             PutObjectRequest request = new PutObjectRequest(bucket, fileName, uploadFile.getInputStream(), metadata);
             s3Client.putObject(request);

--- a/src/main/java/d83t/bpmbackend/security/jwt/JwtService.java
+++ b/src/main/java/d83t/bpmbackend/security/jwt/JwtService.java
@@ -1,6 +1,8 @@
 package d83t.bpmbackend.security.jwt;
 
+import d83t.bpmbackend.domain.aggregate.profile.entity.Profile;
 import d83t.bpmbackend.domain.aggregate.profile.service.UserServiceDetail;
+import d83t.bpmbackend.domain.aggregate.user.entity.User;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
@@ -65,8 +67,8 @@ public class JwtService {
 
     public Authentication getAuthentication(String jwtToken) {
         UserDetails userDetails = userServiceDetail.loadUserByUsername(getNickname(jwtToken));
-
-        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+        User user = (User)userDetails;
+        return new UsernamePasswordAuthenticationToken(user, "", userDetails.getAuthorities());
     }
 
 }

--- a/src/main/java/d83t/bpmbackend/utils/FileUtils.java
+++ b/src/main/java/d83t/bpmbackend/utils/FileUtils.java
@@ -1,0 +1,44 @@
+package d83t.bpmbackend.utils;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.io.File;
+import java.util.UUID;
+
+@Component
+@Slf4j
+public class FileUtils {
+
+    /*
+     * 로컬에 파일 저장할때 그 경로를 리턴합니다.
+     */
+    public static String getUploadPath() {
+        String path = new File("").getAbsolutePath() + "/" + "bodyShapes/";
+        File file = new File(path);
+        if (!file.exists()) {
+            file.mkdir();
+        }
+        return path;
+    }
+
+    /*
+     * 파일 이름 중복을 고려하여, 랜덤한 이름으로 변환합니다.
+     */
+    public static String createNewFileName(String originalName) {
+        return UUID.randomUUID() + "." + originalName.substring(originalName.lastIndexOf("."));
+    }
+
+    /*
+     * 로컬 파일을 삭제합니다.
+     */
+
+    public static void removeNewFile(File targetFile) {
+        if (targetFile.delete()) {
+            log.info("file delete success");
+            return;
+        }
+        log.info("file delete fail");
+    }
+
+}


### PR DESCRIPTION
# 개요
- 내 눈바디 등록 API 구현

# 상세내용
- S3 파일을 관리하는 서비스 추가
- 로컬에 임시로 저장할 파일 및 파일의 이름을 다루는 `static`메서드 추가 및 클래스 추가
- 내 눈바디 등록하기 서비스 API 구현
- 파일에 대한 경로는 `properties`에서 받기로 구현
- 닉네임 중복 관련 에러 추가

