### PR TITLE
D83T-38 내 눈바디 상세 조회 API 작성

### DIFF
--- a/src/main/java/d83t/bpmbackend/domain/aggregate/community/controller/BodyShapeController.java
+++ b/src/main/java/d83t/bpmbackend/domain/aggregate/community/controller/BodyShapeController.java
@@ -21,11 +21,19 @@ public class BodyShapeController {
     private final BodyShapeService bodyShapeService;
 
     @PostMapping
-    public BodyShapeResponse createBoastArticle(
+    public BodyShapeResponse.SigneBodyShapes createBoastArticle(
             @AuthenticationPrincipal User user,
             @RequestPart List<MultipartFile> files,
             @ModelAttribute BodyShapeRequest bodyShapeRequest) {
-        log.info(files.toString());
-        return bodyShapeService.createBoastArticle(user, files, bodyShapeRequest);
+        return BodyShapeResponse.SigneBodyShapes.builder().bodyShapeArticle(bodyShapeService.createBoastArticle(user, files, bodyShapeRequest)).build();
+    }
+
+    @GetMapping
+    public BodyShapeResponse.MultiBodyShapes getBodyShapes(
+            @AuthenticationPrincipal User user,
+            @RequestParam(value = "limit", required = false) Integer limit,
+            @RequestParam(value = "offset", required = false) Integer offset) {
+        List<BodyShapeResponse> bodyShapes = bodyShapeService.getBodyShapes(user, limit, offset);
+        return BodyShapeResponse.MultiBodyShapes.builder().bodyShapeArticles(bodyShapes).bodyShapeCount(bodyShapes.size()).build();
     }
 }

--- a/src/main/java/d83t/bpmbackend/domain/aggregate/community/controller/BodyShapeController.java
+++ b/src/main/java/d83t/bpmbackend/domain/aggregate/community/controller/BodyShapeController.java
@@ -38,12 +38,10 @@ public class BodyShapeController {
     }
 
     @GetMapping("/{bodyShapeId}")
-    public BodyShapeResponse.SigneBodyShapes getBodyShape(
+    public BodyShapeResponse.SingleBodyShape getBodyShape(
             @AuthenticationPrincipal User user,
-            @PathVariable Long bodyShapeId){
-        return BodyShapeResponse.SigneBodyShapes.builder().bodyShapeArticle(bodyShapeService.getBodyShape(user,bodyShapeId)).build();
+            @PathVariable Long bodyShapeId) {
+        return BodyShapeResponse.SingleBodyShape.builder().bodyShapeArticle(bodyShapeService.getBodyShape(user, bodyShapeId)).build();
     }
 
-
-    )
 }

--- a/src/main/java/d83t/bpmbackend/domain/aggregate/community/controller/BodyShapeController.java
+++ b/src/main/java/d83t/bpmbackend/domain/aggregate/community/controller/BodyShapeController.java
@@ -36,4 +36,14 @@ public class BodyShapeController {
         List<BodyShapeResponse> bodyShapes = bodyShapeService.getBodyShapes(user, limit, offset);
         return BodyShapeResponse.MultiBodyShapes.builder().bodyShapeArticles(bodyShapes).bodyShapeCount(bodyShapes.size()).build();
     }
+
+    @GetMapping("/{bodyShapeId}")
+    public BodyShapeResponse.SigneBodyShapes getBodyShape(
+            @AuthenticationPrincipal User user,
+            @PathVariable Long bodyShapeId){
+        return BodyShapeResponse.SigneBodyShapes.builder().bodyShapeArticle(bodyShapeService.getBodyShape(user,bodyShapeId)).build();
+    }
+
+
+    )
 }

--- a/src/main/java/d83t/bpmbackend/domain/aggregate/community/dto/BodyShapeResponse.java
+++ b/src/main/java/d83t/bpmbackend/domain/aggregate/community/dto/BodyShapeResponse.java
@@ -11,6 +11,7 @@ import java.util.List;
 @Builder
 @Getter
 public class BodyShapeResponse {
+    private Long id;
     private String content;
 
     private ZonedDateTime createdAt;

--- a/src/main/java/d83t/bpmbackend/domain/aggregate/community/dto/BodyShapeResponse.java
+++ b/src/main/java/d83t/bpmbackend/domain/aggregate/community/dto/BodyShapeResponse.java
@@ -4,15 +4,12 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import lombok.Builder;
 import lombok.Getter;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.time.ZonedDateTime;
 import java.util.List;
 
 @Builder
 @Getter
-@JsonTypeName("boast")
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
 public class BodyShapeResponse {
     private String content;
 
@@ -28,5 +25,18 @@ public class BodyShapeResponse {
     public static class Author{
         private String nickname;
         private String profilePath;
+    }
+
+    @Builder
+    @Getter
+    public static class SigneBodyShapes{
+        BodyShapeResponse bodyShapeArticle;
+    }
+
+    @Builder
+    @Getter
+    public static class MultiBodyShapes{
+        List<BodyShapeResponse> bodyShapeArticles;
+        Integer bodyShapeCount;
     }
 }

--- a/src/main/java/d83t/bpmbackend/domain/aggregate/community/repository/BodyShapeRepository.java
+++ b/src/main/java/d83t/bpmbackend/domain/aggregate/community/repository/BodyShapeRepository.java
@@ -1,7 +1,14 @@
 package d83t.bpmbackend.domain.aggregate.community.repository;
 
 import d83t.bpmbackend.domain.aggregate.community.entity.BodyShape;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface BodyShapeRepository extends JpaRepository<BodyShape, Long> {
+
+    @Query("SELECT a FROM BodyShape a ORDER BY a.createdDate DESC")
+    List<BodyShape> findByAll(Pageable pageable);
 }

--- a/src/main/java/d83t/bpmbackend/domain/aggregate/community/service/BodyShapeService.java
+++ b/src/main/java/d83t/bpmbackend/domain/aggregate/community/service/BodyShapeService.java
@@ -13,4 +13,6 @@ public interface BodyShapeService {
     BodyShapeResponse createBoastArticle(User user, List<MultipartFile> files, BodyShapeRequest boastArticleRequest);
 
     List<BodyShapeResponse> getBodyShapes(User user, Integer limit, Integer offset);
+
+    BodyShapeResponse getBodyShape(User user, Long bodyShapeId);
 }

--- a/src/main/java/d83t/bpmbackend/domain/aggregate/community/service/BodyShapeService.java
+++ b/src/main/java/d83t/bpmbackend/domain/aggregate/community/service/BodyShapeService.java
@@ -11,4 +11,6 @@ public interface BodyShapeService {
 
 
     BodyShapeResponse createBoastArticle(User user, List<MultipartFile> files, BodyShapeRequest boastArticleRequest);
+
+    List<BodyShapeResponse> getBodyShapes(User user, Integer limit, Integer offset);
 }

--- a/src/main/java/d83t/bpmbackend/domain/aggregate/community/service/BodyShapeServiceImpl.java
+++ b/src/main/java/d83t/bpmbackend/domain/aggregate/community/service/BodyShapeServiceImpl.java
@@ -100,6 +100,7 @@ public class BodyShapeServiceImpl implements BodyShapeService {
         bodyShapeRepository.save(bodyshape);
 
         return BodyShapeResponse.builder()
+                .id(bodyshape.getId())
                 .createdAt(bodyshape.getCreatedDate())
                 .author(BodyShapeResponse.Author.builder()
                         .nickname(profile.getNickName())
@@ -122,6 +123,7 @@ public class BodyShapeServiceImpl implements BodyShapeService {
 
         return bodyShapes.stream().map(bodyShape -> {
             return BodyShapeResponse.builder()
+                    .id(bodyShape.getId())
                     .content(bodyShape.getContent())
                     .createdAt(bodyShape.getCreatedDate())
                     .updatedAt(bodyShape.getModifiedDate())

--- a/src/main/java/d83t/bpmbackend/domain/aggregate/community/service/BodyShapeServiceImpl.java
+++ b/src/main/java/d83t/bpmbackend/domain/aggregate/community/service/BodyShapeServiceImpl.java
@@ -138,11 +138,31 @@ public class BodyShapeServiceImpl implements BodyShapeService {
         }).collect(Collectors.toList());
     }
 
+    //TODO: 향후 public, private 구분이 되는 기능이 추가될 시 Response를 바꿔야함.
     @Override
     public BodyShapeResponse getBodyShape(User user, Long bodyShapeId) {
-
-
-        return null;
+        Optional<BodyShape> findBodyShape = bodyShapeRepository.findById(bodyShapeId);
+        if(findBodyShape.isEmpty()){
+            throw new CustomException(Error.NOT_FOUND_BODY_SHAPE);
+        }
+        BodyShape bodyShape = findBodyShape.get();
+        List<String> filePaths = new ArrayList<>();
+        Profile author = bodyShape.getAuthor();
+        List<BodyShapeImage> images = bodyShape.getImages();
+        for(BodyShapeImage image : images){
+            filePaths.add(image.getStoragePathName());
+        }
+        return BodyShapeResponse.builder()
+                .id(bodyShape.getId())
+                .createdAt(bodyShape.getCreatedDate())
+                .author(BodyShapeResponse.Author.builder()
+                        .nickname(author.getNickName())
+                        .profilePath(author.getStoragePathName())
+                        .build())
+                .updatedAt(bodyShape.getModifiedDate())
+                .filesPath(filePaths)
+                .content(bodyShape.getContent())
+                .build();
     }
 
 }

--- a/src/main/java/d83t/bpmbackend/domain/aggregate/community/service/BodyShapeServiceImpl.java
+++ b/src/main/java/d83t/bpmbackend/domain/aggregate/community/service/BodyShapeServiceImpl.java
@@ -138,4 +138,11 @@ public class BodyShapeServiceImpl implements BodyShapeService {
         }).collect(Collectors.toList());
     }
 
+    @Override
+    public BodyShapeResponse getBodyShape(User user, Long bodyShapeId) {
+
+
+        return null;
+    }
+
 }

--- a/src/main/java/d83t/bpmbackend/exception/Error.java
+++ b/src/main/java/d83t/bpmbackend/exception/Error.java
@@ -11,6 +11,7 @@ public enum Error {
     S3_UPLOAD_FAIL("upload fail", HttpStatus.INTERNAL_SERVER_ERROR),
     S3_GET_FILE_FAIL("fail to get file", HttpStatus.INTERNAL_SERVER_ERROR),
     DUPLICATE_USER_NICK_NAME("duplicate user nickname", HttpStatus.CONFLICT),
+    NOT_FOUND_BODY_SHAPE("bodyshape article not found",HttpStatus.NOT_FOUND),
     FILE_SIZE_MAX("a Maximum of 5 files can Come in", HttpStatus.BAD_REQUEST);
 
     private final String message;


### PR DESCRIPTION
# 개요
- 내 눈바디 상세 조회 API 작성

# 상세내용
- 내 눈바디 id를 가지고 단일 조회를 합니다.
- 리스트조회시에 이미 유저를 검증하므로, 해당 로직에서 작성자를 확인하는 로직은 작성하지 않았습니다.

향후 게시글을 public으로 보여주는 기능이 생길시 작성해야합니다.

# 테스트
- Postman
![image](https://user-images.githubusercontent.com/30401054/221617230-c58cf860-bce0-408b-b808-75b2d72e9958.png)

