### PR TITLE
D83T-41 내 눈바디 삭제 API 구현

### DIFF
--- a/src/main/java/d83t/bpmbackend/domain/aggregate/community/controller/BodyShapeController.java
+++ b/src/main/java/d83t/bpmbackend/domain/aggregate/community/controller/BodyShapeController.java
@@ -44,4 +44,11 @@ public class BodyShapeController {
         return BodyShapeResponse.SingleBodyShape.builder().bodyShapeArticle(bodyShapeService.getBodyShape(user, bodyShapeId)).build();
     }
 
+    @DeleteMapping("/{bodyShapeId}")
+    public void deleteBodyShape(
+            @AuthenticationPrincipal User user,
+            @PathVariable Long bodyShapeId) {
+        bodyShapeService.deleteBodyShape(user, bodyShapeId);
+    }
+
 }

--- a/src/main/java/d83t/bpmbackend/domain/aggregate/community/controller/BodyShapeController.java
+++ b/src/main/java/d83t/bpmbackend/domain/aggregate/community/controller/BodyShapeController.java
@@ -38,12 +38,10 @@ public class BodyShapeController {
     }
 
     @GetMapping("/{bodyShapeId}")
-    public BodyShapeResponse.SigneBodyShapes getBodyShape(
+    public BodyShapeResponse.SingleBodyShape getBodyShape(
             @AuthenticationPrincipal User user,
-            @PathVariable Long bodyShapeId){
-        return BodyShapeResponse.SigneBodyShapes.builder().bodyShapeArticle(bodyShapeService.getBodyShape(user,bodyShapeId)).build();
+            @PathVariable Long bodyShapeId) {
+        return BodyShapeResponse.SingleBodyShape.builder().bodyShapeArticle(bodyShapeService.getBodyShape(user, bodyShapeId)).build();
     }
 
-
-    )
 }

--- a/src/main/java/d83t/bpmbackend/domain/aggregate/community/controller/BodyShapeController.java
+++ b/src/main/java/d83t/bpmbackend/domain/aggregate/community/controller/BodyShapeController.java
@@ -36,4 +36,14 @@ public class BodyShapeController {
         List<BodyShapeResponse> bodyShapes = bodyShapeService.getBodyShapes(user, limit, offset);
         return BodyShapeResponse.MultiBodyShapes.builder().bodyShapeArticles(bodyShapes).bodyShapeCount(bodyShapes.size()).build();
     }
+
+    @GetMapping("/{bodyShapeId}")
+    public BodyShapeResponse.SigneBodyShapes getBodyShape(
+            @AuthenticationPrincipal User user,
+            @PathVariable Long bodyShapeId){
+        return BodyShapeResponse.SigneBodyShapes.builder().bodyShapeArticle(bodyShapeService.getBodyShape(user,bodyShapeId)).build();
+    }
+
+
+    )
 }

--- a/src/main/java/d83t/bpmbackend/domain/aggregate/community/service/BodyShapeService.java
+++ b/src/main/java/d83t/bpmbackend/domain/aggregate/community/service/BodyShapeService.java
@@ -13,4 +13,6 @@ public interface BodyShapeService {
     BodyShapeResponse createBoastArticle(User user, List<MultipartFile> files, BodyShapeRequest boastArticleRequest);
 
     List<BodyShapeResponse> getBodyShapes(User user, Integer limit, Integer offset);
+
+    BodyShapeResponse getBodyShape(User user, Long bodyShapeId);
 }

--- a/src/main/java/d83t/bpmbackend/domain/aggregate/community/service/BodyShapeService.java
+++ b/src/main/java/d83t/bpmbackend/domain/aggregate/community/service/BodyShapeService.java
@@ -15,4 +15,6 @@ public interface BodyShapeService {
     List<BodyShapeResponse> getBodyShapes(User user, Integer limit, Integer offset);
 
     BodyShapeResponse getBodyShape(User user, Long bodyShapeId);
+
+    void deleteBodyShape(User user, Long bodyShapeId);
 }

--- a/src/main/java/d83t/bpmbackend/domain/aggregate/community/service/BodyShapeServiceImpl.java
+++ b/src/main/java/d83t/bpmbackend/domain/aggregate/community/service/BodyShapeServiceImpl.java
@@ -174,7 +174,12 @@ public class BodyShapeServiceImpl implements BodyShapeService {
     //TODO: 마찬가지로 향후 public이 생길시 작성 유저인지 판단하는 로직 추가
     @Override
     public void deleteBodyShape(User user, Long bodyShapeId) {
-
+        Optional<BodyShape> findBodyShape = bodyShapeRepository.findById(bodyShapeId);
+        if(findBodyShape.isEmpty()){
+            throw new CustomException(Error.NOT_FOUND_BODY_SHAPE);
+        }
+        BodyShape bodyShape = findBodyShape.get();
+        bodyShapeRepository.delete(bodyShape);
     }
 
 }

--- a/src/main/java/d83t/bpmbackend/domain/aggregate/community/service/BodyShapeServiceImpl.java
+++ b/src/main/java/d83t/bpmbackend/domain/aggregate/community/service/BodyShapeServiceImpl.java
@@ -165,4 +165,10 @@ public class BodyShapeServiceImpl implements BodyShapeService {
                 .build();
     }
 
+    //TODO: 마찬가지로 향후 public이 생길시 작성 유저인지 판단하는 로직 추가
+    @Override
+    public void deleteBodyShape(User user, Long bodyShapeId) {
+
+    }
+
 }

--- a/src/main/java/d83t/bpmbackend/domain/aggregate/community/service/BodyShapeServiceImpl.java
+++ b/src/main/java/d83t/bpmbackend/domain/aggregate/community/service/BodyShapeServiceImpl.java
@@ -138,11 +138,31 @@ public class BodyShapeServiceImpl implements BodyShapeService {
         }).collect(Collectors.toList());
     }
 
+    //TODO: 향후 public, private 구분이 되는 기능이 추가될 시 Response를 바꿔야함.
     @Override
     public BodyShapeResponse getBodyShape(User user, Long bodyShapeId) {
-
-
-        return null;
+        Optional<BodyShape> findBodyShape = bodyShapeRepository.findById(bodyShapeId);
+        if(findBodyShape.isEmpty()){
+            throw new CustomException(Error.NOT_FOUND_BODY_SHAPE);
+        }
+        BodyShape bodyShape = findBodyShape.get();
+        List<String> filePaths = new ArrayList<>();
+        Profile author = bodyShape.getAuthor();
+        List<BodyShapeImage> images = bodyShape.getImages();
+        for(BodyShapeImage image : images){
+            filePaths.add(image.getStoragePathName());
+        }
+        return BodyShapeResponse.builder()
+                .id(bodyShape.getId())
+                .createdAt(bodyShape.getCreatedDate())
+                .author(BodyShapeResponse.Author.builder()
+                        .nickname(author.getNickName())
+                        .profilePath(author.getStoragePathName())
+                        .build())
+                .updatedAt(bodyShape.getModifiedDate())
+                .filesPath(filePaths)
+                .content(bodyShape.getContent())
+                .build();
     }
 
 }

--- a/src/main/java/d83t/bpmbackend/domain/aggregate/community/service/BodyShapeServiceImpl.java
+++ b/src/main/java/d83t/bpmbackend/domain/aggregate/community/service/BodyShapeServiceImpl.java
@@ -138,4 +138,11 @@ public class BodyShapeServiceImpl implements BodyShapeService {
         }).collect(Collectors.toList());
     }
 
+    @Override
+    public BodyShapeResponse getBodyShape(User user, Long bodyShapeId) {
+
+
+        return null;
+    }
+
 }

--- a/src/main/java/d83t/bpmbackend/exception/Error.java
+++ b/src/main/java/d83t/bpmbackend/exception/Error.java
@@ -11,6 +11,7 @@ public enum Error {
     S3_UPLOAD_FAIL("upload fail", HttpStatus.INTERNAL_SERVER_ERROR),
     S3_GET_FILE_FAIL("fail to get file", HttpStatus.INTERNAL_SERVER_ERROR),
     DUPLICATE_USER_NICK_NAME("duplicate user nickname", HttpStatus.CONFLICT),
+    NOT_FOUND_BODY_SHAPE("bodyshape article not found",HttpStatus.NOT_FOUND),
     FILE_SIZE_MAX("a Maximum of 5 files can Come in", HttpStatus.BAD_REQUEST);
 
     private final String message;


### PR DESCRIPTION
# 개요
- 내 눈바디 삭제 API 구현

# 상세내용
- 내 눈바디 삭제 API를 구현하였습니다.

단일조회와 마찬가지로 유저검증은 하지 않았습니다. 향후 public으로 조회하는 기능이 생길 시 추가해야합니다.

# 테스트
- postman

삭제 전

![image](https://user-images.githubusercontent.com/30401054/221618152-70767899-d7fd-493a-898a-868a838ddeb6.png)

삭제 후

![image](https://user-images.githubusercontent.com/30401054/221618223-5f888ba7-9433-4d04-afcc-758084c3b489.png)
