### PR TITLE
[D83T-53] 내 일정등록할때 스튜디오 이름 없어도 받게끔 변경

### DIFF
--- a/src/main/java/d83t/bpmbackend/domain/aggregate/user/entity/Schedule.java
+++ b/src/main/java/d83t/bpmbackend/domain/aggregate/user/entity/Schedule.java
@@ -36,7 +36,7 @@ public class Schedule {
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(nullable = false)
+    @JoinColumn(name = "studio_id", referencedColumnName = "id")
     private Studio studio;
 
 }

--- a/src/main/java/d83t/bpmbackend/domain/aggregate/user/service/UserServiceImpl.java
+++ b/src/main/java/d83t/bpmbackend/domain/aggregate/user/service/UserServiceImpl.java
@@ -84,10 +84,10 @@ public class UserServiceImpl implements UserService {
     @Override
     public ScheduleResponse registerSchedule(User user, ScheduleRequest scheduleRequest) {
         Optional<Studio> findStudio = studioRepository.findByName(scheduleRequest.getStudioName());
-        if (findStudio.isEmpty()) {
-            throw new CustomException(Error.NOT_FOUND_STUDIO);
+        Studio studio = null;
+        if (findStudio.isPresent()) {
+            studio = findStudio.get();
         }
-        Studio studio = findStudio.get();
 
         Schedule schedule = Schedule.builder()
                 .studio(studio)
@@ -97,6 +97,7 @@ public class UserServiceImpl implements UserService {
                 .memo(scheduleRequest.getMemo())
                 .build();
         scheduleRepository.save(schedule);
+
         return ScheduleResponse.builder()
                 .studioName(scheduleRequest.getStudioName())
                 .time(schedule.getTime())


### PR DESCRIPTION
# 개요
- 내 일정등록할때 스튜디오 이름 없어도 받게끔 변경

# 상세내용
- MVP에서는 스튜디오 이름 필수로 안받아도 되게끔 변경하였습니다.

